### PR TITLE
docs(long_description): Set long description content type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setuptools.setup(
   version="0.1.1",
   description="TensorBoard plugin for 3D visualization",
   long_description=long_description,
+  long_description_content_type='text/markdown',
   cmdclass={
     "build_client": build_client
   },


### PR DESCRIPTION
This ensures that markdown is rendered correctly on PyPI. Checked locally and passed with [twine check](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup).

Fixes #28