### PR TITLE
feat(image order): Serve the first image first

### DIFF
--- a/tensorboard_plugin_3d/plugin.py
+++ b/tensorboard_plugin_3d/plugin.py
@@ -76,8 +76,8 @@ class TensorboardPlugin3D(base_plugin.TBPlugin):
         elif idx:
             data = self._find_next_images(idx)
         else:
-            # Grab the most recent run (event file)
-            data = self._find_most_recent()
+            # Grab the first run (event file)
+            data = self._find_next_images(1)
 
         response = {}
         for tag, images in data.items():
@@ -154,16 +154,6 @@ class TensorboardPlugin3D(base_plugin.TBPlugin):
         self.current_run = (int(idx) - 1) % len(self._all_runs)
         run = self._all_runs[self.current_run]
         return self._all_images[run]
-
-    def _find_most_recent(self):
-        newest = -1
-        for run, tags in self._all_images.items():
-            times = [i.wall_time for v in tags.values() for i in v]
-            if newest < (new_time := max(times)):
-                most_recent = tags
-                newest = new_time
-                self.current_run = self._all_runs.index(run)
-        return most_recent
 
     def _find_all_images(self):
         """


### PR DESCRIPTION
Previously the most recent image was served first to match the pattern used by the TensorBoard Images plugin. Now that we have the ability to toggle through all output I think it makes more sense to start at the beginning.

@thewtex Let me know what you think about this change. If we should keep what we have that is fine. I am just finding it odd (even though I know the logic behind it) to always start with the last image now that we can toggle. Since most of the time people will likely be writing out all the images at once they would likely always start at the last image. Plus if there has been an update it's simple enough to jump to that now with the arrows (which do support fast clicking) or typing in the exact image number.